### PR TITLE
Update checkout action for Node 24

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
## Summary
- Updates the Rust CI workflow from `actions/checkout@v3` to `actions/checkout@v6`.
- Addresses GitHub Actions Node.js 20 deprecation warnings ahead of the Node 24 default runtime migration.

## Testing
- Not run locally; workflow-only change.